### PR TITLE
Bumped grunt-contrib-concat version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"dependencies": {
 		"grunt-bower-task": "~0.4.0",
 		"grunt-contrib-clean": "~0.7.0",
-		"grunt-contrib-concat": "~0.5.0",
+		"grunt-contrib-concat": "~0.5.1",
 		"grunt-contrib-jshint": "~0.11.0",
 		"grunt-contrib-less": "~1.1.0",
 		"grunt-contrib-uglify": "~0.10.0",


### PR DESCRIPTION
When building Pixi, grunt-contrib-concat fails erroring: sourceMap: ENAMETOOLONG. This is a reported issue in grunt-contrib-concat [#144](https://github.com/gruntjs/grunt-contrib-concat/issues/144). This was fixed and released in grunt-contrib-concat version 0.5.1.
