### PR TITLE
Allows for patterns in librariesCopy

### DIFF
--- a/libs/springroll-json.js
+++ b/libs/springroll-json.js
@@ -86,15 +86,11 @@ module.exports = function(grunt, options)
 	grunt.config.set('hasCopy', hasCopy);
 
 	// Format into format for grunt-contrib-copy
-	if (hasCopy)
-	{
+	if (hasCopy) {
 		librariesCopy = {};
-		_.each(file.librariesCopy, function(dest, src){
-			var id = path.basename(src)
-				.replace(/[^a-zA-Z0-9]/g, '')
-				.toLowerCase();
-
-			librariesCopy[id] = {
+		var id = 0;
+		_.each(file.librariesCopy, function (dest, src) {
+			librariesCopy[id++] = {
 				src: src,
 				dest: dest,
 				expand: true,
@@ -102,6 +98,7 @@ module.exports = function(grunt, options)
 			};
 		});
 	}
+
 
 	return {
 


### PR DESCRIPTION
Okay, you might notice this commit is from two years ago... however I was cleaning up my forks and I realized this might be worth merging in.

I wanted be able to use patterns in the library copy task. The only thing stopping me was [the replace](https://github.com/SpringRoll/grunt-springroll/blob/bd3e0828d6da2c575b982e2bb59c756673277b4f/libs/springroll-json.js#L94).

The outcome of removing that is that all of these are valid and work as expected:
```js
"librariesCopy": {
    "components/soundjs/lib/FlashAudioPlugin.swf": "deploy/assets/swfs/",
    "src/assets/audio/sfx/*": "deploy/assets/audio/sfx/",
    "src/assets/audio/music/*": "deploy/assets/audio/music/",
    "src/assets/audio/vo/*": "deploy/assets/audio/vo/"
  }
```